### PR TITLE
Fix 400 Bad Request

### DIFF
--- a/internal/ngsicmd/remove.go
+++ b/internal/ngsicmd/remove.go
@@ -106,9 +106,10 @@ func remove(c *cli.Context) error {
 		if err != nil {
 			return &ngsiCmdError{funcName, 9, err.Error(), err}
 		}
+		client.RemoveHeader("Content-Type")
 	}
 
-	fmt.Fprintf(ngsi.StdWriter, "%d", total)
+	fmt.Fprintf(ngsi.StdWriter, "%d\n", total)
 
 	return nil
 }


### PR DESCRIPTION
This PR fixes `Fix 400 Bad Request` in rm command.

```
remove006 400 Bad Request {"error":"BadRequest","description":"Orion accepts no payload for GET/DELETE requests. HTTP header Content-Type is thus forbidden"}
```