### PR TITLE
Enable verbose mode when some options are specified

### DIFF
--- a/internal/ngsicmd/entities.go
+++ b/internal/ngsicmd/entities.go
@@ -61,7 +61,7 @@ func entitiesList(c *cli.Context) error {
 	limit := 100
 
 	verbose := c.IsSet("verbose")
-	if c.Bool("pretty") {
+	if c.Bool("pretty") || c.Bool("keyValues") || isSetOR(c, []string{"attrs", "metadata", "orderBy"}) {
 		verbose = true
 	}
 	values := c.IsSet("values")


### PR DESCRIPTION
This PR updates list entities command. It enables verbose mode when the following options are specified.

`--keyValues, --attrs, --metadata, --orderBy`