### PR TITLE
Fix error that null is displayed when number of registrations is 0.

### DIFF
--- a/internal/ngsicmd/registrationsLd.go
+++ b/internal/ngsicmd/registrationsLd.go
@@ -128,19 +128,21 @@ func registrationsListLd(c *cli.Context, ngsi *ngsilib.NGSI, client *ngsilib.Cli
 	}
 
 	if c.IsSet("json") || c.Bool("pretty") {
-		b, err := ngsilib.JSONMarshal(registrations)
-		if err != nil {
-			return &ngsiCmdError{funcName, 5, err.Error(), err}
-		}
-		if c.Bool("pretty") {
-			newBuf := new(bytes.Buffer)
-			err := ngsi.JSONConverter.Indent(newBuf, b, "", "  ")
+		if len(registrations) > 0 {
+			b, err := ngsilib.JSONMarshal(registrations)
 			if err != nil {
-				return &ngsiCmdError{funcName, 6, err.Error(), err}
+				return &ngsiCmdError{funcName, 5, err.Error(), err}
 			}
-			fmt.Fprintln(ngsi.StdWriter, string(newBuf.Bytes()))
-		} else {
-			fmt.Fprintln(ngsi.StdWriter, string(b))
+			if c.Bool("pretty") {
+				newBuf := new(bytes.Buffer)
+				err := ngsi.JSONConverter.Indent(newBuf, b, "", "  ")
+				if err != nil {
+					return &ngsiCmdError{funcName, 6, err.Error(), err}
+				}
+				fmt.Fprintln(ngsi.StdWriter, string(newBuf.Bytes()))
+			} else {
+				fmt.Fprintln(ngsi.StdWriter, string(b))
+			}
 		}
 	} else if c.IsSet("verbose") {
 		local := c.IsSet("localTime")

--- a/internal/ngsicmd/registrationsLd_test.go
+++ b/internal/ngsicmd/registrationsLd_test.go
@@ -133,6 +133,38 @@ func TestRegistrationsListLdCountZero(t *testing.T) {
 	}
 }
 
+func TestRegistrationsListLdCountZeroPretty(t *testing.T) {
+	ngsi, set, app, buf := setupTest()
+
+	reqRes := MockHTTPReqRes{}
+	reqRes.Res.StatusCode = http.StatusOK
+	reqRes.ResBody = []byte(`[{"id":"5f5dcb551e715bc7f1ad79e3","description":"sensor source","endpoint":"http://raspi","information":[{"entities":[{"id":"urn:ngsi-ld:Device:device001","type":"Device"}],"properties":["temperature","pressure","humidity"]}],"type":"ContextSourceRegistration"}]`)
+	reqRes.ResHeader = http.Header{"Ngsild-Results-Count": []string{"0"}}
+	reqRes.Path = "/ngsi-ld/v1/csourceRegistrations/"
+	mock := NewMockHTTP()
+	mock.ReqRes = append(mock.ReqRes, reqRes)
+	ngsi.HTTP = mock
+
+	setupFlagString(set, "host")
+	setupFlagBool(set, "pretty")
+	c := cli.NewContext(app, set, nil)
+	_ = set.Parse([]string{"--host=orion-ld", "--pretty"})
+
+	ngsi, err := initCmd(c, "", true)
+	assert.NoError(t, err)
+	client, err := newClient(ngsi, c, false)
+	assert.NoError(t, err)
+	err = registrationsListLd(c, ngsi, client)
+
+	if assert.NoError(t, err) {
+		actual := buf.String()
+		expected := ""
+		assert.Equal(t, expected, actual)
+	} else {
+		t.FailNow()
+	}
+}
+
 func TestRegistrationsListLdCountPage(t *testing.T) {
 	ngsi, set, app, buf := setupTest()
 

--- a/internal/ngsicmd/registrationsV2.go
+++ b/internal/ngsicmd/registrationsV2.go
@@ -139,19 +139,21 @@ func registrationsListV2(c *cli.Context, ngsi *ngsilib.NGSI, client *ngsilib.Cli
 	}
 
 	if c.IsSet("json") || c.Bool("pretty") {
-		b, err := ngsilib.JSONMarshal(registrations)
-		if err != nil {
-			return &ngsiCmdError{funcName, 5, err.Error(), err}
-		}
-		if c.Bool("pretty") {
-			newBuf := new(bytes.Buffer)
-			err := ngsi.JSONConverter.Indent(newBuf, b, "", "  ")
+		if len(registrations) > 0 {
+			b, err := ngsilib.JSONMarshal(registrations)
 			if err != nil {
-				return &ngsiCmdError{funcName, 6, err.Error(), err}
+				return &ngsiCmdError{funcName, 5, err.Error(), err}
 			}
-			fmt.Fprintln(ngsi.StdWriter, string(newBuf.Bytes()))
-		} else {
-			fmt.Fprintln(ngsi.StdWriter, string(b))
+			if c.Bool("pretty") {
+				newBuf := new(bytes.Buffer)
+				err := ngsi.JSONConverter.Indent(newBuf, b, "", "  ")
+				if err != nil {
+					return &ngsiCmdError{funcName, 6, err.Error(), err}
+				}
+				fmt.Fprintln(ngsi.StdWriter, string(newBuf.Bytes()))
+			} else {
+				fmt.Fprintln(ngsi.StdWriter, string(b))
+			}
 		}
 	} else if c.IsSet("verbose") {
 		local := c.IsSet("localTime")

--- a/internal/ngsicmd/registrationsV2_test.go
+++ b/internal/ngsicmd/registrationsV2_test.go
@@ -101,6 +101,39 @@ func TestRegistrationsListV2CountZero(t *testing.T) {
 	}
 }
 
+func TestRegistrationsListV2CountZeroPretty(t *testing.T) {
+	ngsi, set, app, buf := setupTest()
+
+	reqRes := MockHTTPReqRes{}
+	reqRes.Res.StatusCode = http.StatusOK
+	reqRes.ResBody = []byte(`[{"id":"5f5dcb551e715bc7f1ad79e3","description":"sensor source","endpoint":"http://raspi","information":[{"entities":[{"id":"urn:ngsi-ld:Device:device001","type":"Device"}],"properties":["temperature","pressure","humidity"]}],"type":"ContextSourceRegistration"}]`)
+	reqRes.ResHeader = http.Header{"Fiware-Total-Count": []string{"0"}}
+	reqRes.Path = "/v2/registrations"
+	mock := NewMockHTTP()
+	mock.ReqRes = append(mock.ReqRes, reqRes)
+	ngsi.HTTP = mock
+
+	setupFlagString(set, "host")
+	setupFlagBool(set, "pretty")
+	c := cli.NewContext(app, set, nil)
+	_ = set.Parse([]string{"--host=orion", "--pretty"})
+
+	ngsi, err := initCmd(c, "", true)
+	assert.NoError(t, err)
+	client, err := newClient(ngsi, c, false)
+	assert.NoError(t, err)
+
+	err = registrationsListV2(c, ngsi, client)
+
+	if assert.NoError(t, err) {
+		actual := buf.String()
+		expected := ""
+		assert.Equal(t, expected, actual)
+	} else {
+		t.FailNow()
+	}
+}
+
 func TestRegistrationsListV2Page(t *testing.T) {
 	ngsi, set, app, buf := setupTest()
 


### PR DESCRIPTION
This PR fixes error that null is displayed when number of registrations is 0.

```
$ ngsi list registrations -P
null
```