### PR TITLE
Fix nil pointer dereference in template subscription

### DIFF
--- a/internal/ngsicmd/subscriptionsV2.go
+++ b/internal/ngsicmd/subscriptionsV2.go
@@ -464,13 +464,22 @@ func setSubscriptionValuesV2(c *cli.Context, ngsi *ngsilib.NGSI, t *subscription
 	if c.IsSet("type") && c.IsSet("typePattern") {
 		return &ngsiCmdError{funcName, 4, "type or typePattern", nil}
 	}
-	if c.IsSet("type") {
-		t.Subject.Entities[0].Type = c.String("type")
-		t.Subject.Entities[0].TypePattern = ""
-	}
-	if c.IsSet("typePattern") {
-		t.Subject.Entities[0].TypePattern = c.String("typePattern")
-		t.Subject.Entities[0].Type = ""
+
+	if c.IsSet("type") || c.IsSet("typePattern") {
+		if t.Subject == nil {
+			t.Subject = new(subscriptionSubjectV2)
+		}
+		if len(t.Subject.Entities) == 0 {
+			t.Subject.Entities = append(t.Subject.Entities, *new(subscriptionEntityV2))
+		}
+		if c.IsSet("type") {
+			t.Subject.Entities[0].Type = c.String("type")
+			t.Subject.Entities[0].TypePattern = ""
+		}
+		if c.IsSet("typePattern") {
+			t.Subject.Entities[0].TypePattern = c.String("typePattern")
+			t.Subject.Entities[0].Type = ""
+		}
 	}
 
 	if isSetOR(c, []string{"wAttrs", "query", "mq", "georel", "geometry", "coords"}) {

--- a/internal/ngsicmd/subscriptionsV2_test.go
+++ b/internal/ngsicmd/subscriptionsV2_test.go
@@ -1505,7 +1505,7 @@ func TestSetSubscriptionValuesV2TypePattern(t *testing.T) {
 
 	setupFlagString(set, "typePattern,data,entityId,idPattern,url")
 	c := cli.NewContext(app, set, nil)
-	_ = set.Parse([]string{"--data={}", "--idPattern=abc", "--typePattern=abc", "--url=http://ngsiproxy"})
+	_ = set.Parse([]string{"--data={}", "--typePattern=abc", "--url=http://ngsiproxy"})
 
 	err := setSubscriptionValuesV2(c, ngsi, &sub, false)
 


### PR DESCRIPTION
## Proposed changes

This PR fixes nil pointer dereference in template subscription.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

```console
ngsi template subscription --ngsiType v2 --type Thing
```
```console
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7ead99]

goroutine 1 [running]:
github.com/lets-fiware/ngsi-go/internal/ngsicmd.setSubscriptionValuesV2(0xc0000b3e80, 0xc0000ed180, 0xc0000cc640, 0x0, 0x413a3d, 0xc000200b68)
        /home/ksmainte/go/src/github.com/fisuda/ngsi-go/internal/ngsicmd/subscriptionsV2.go:468 +0x2039
github.com/lets-fiware/ngsi-go/internal/ngsicmd.subscriptionsTemplateV2(0xc0000b3e80, 0xc0000ed180, 0x7fff31dd5401, 0x2)
        /home/ksmainte/go/src/github.com/fisuda/ngsi-go/internal/ngsicmd/subscriptionsV2.go:407 +0x74
github.com/lets-fiware/ngsi-go/internal/ngsicmd.subscriptionsTemplate(0xc0000b3e80, 0xc0000ee500, 0xc0000ee820)
        /home/ksmainte/go/src/github.com/fisuda/ngsi-go/internal/ngsicmd/subscriptions.go:150 +0x33c
github.com/lets-fiware/ngsi-go/internal/ngsicmd.glob..func10(0xc0000b3e80, 0x2b, 0x58)
        /home/ksmainte/go/src/github.com/fisuda/ngsi-go/internal/ngsicmd/ngsi.go:360 +0x2b
github.com/urfave/cli/v2.(*Command).Run(0xb70fc0, 0xc0000b3100, 0x0, 0x0)
        /home/ksmainte/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:164 +0x4dd
github.com/urfave/cli/v2.(*App).RunAsSubcommand(0xc000082600, 0xc0000b2dc0, 0x0, 0x0)
        /home/ksmainte/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:427 +0xa49
github.com/urfave/cli/v2.(*Command).startApp(0xb78160, 0xc0000b2dc0, 0x7fff31dd5484, 0x8)
        /home/ksmainte/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:279 +0x6bb
github.com/urfave/cli/v2.(*Command).Run(0xb78160, 0xc0000b2dc0, 0x0, 0x0)
        /home/ksmainte/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/command.go:94 +0x9cd
github.com/urfave/cli/v2.(*App).RunContext(0xc000082480, 0x93a0d0, 0xc0000aa010, 0xc0000b4000, 0x7, 0x7, 0x0, 0x0)
        /home/ksmainte/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:306 +0x810
github.com/urfave/cli/v2.(*App).Run(...)
        /home/ksmainte/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:215
github.com/lets-fiware/ngsi-go/internal/ngsicmd.Run(0xc0000b4000, 0x7, 0x7, 0x9332a0, 0xc0000ae000, 0x9332c0, 0xc0000ae008, 0x9332c0, 0xc0000ae010, 0x0)
        /home/ksmainte/go/src/github.com/fisuda/ngsi-go/internal/ngsicmd/ngsi.go:69 +0x317
main.main()
        /home/ksmainte/go/src/github.com/fisuda/ngsi-go/cmd/ngsi/main.go:44 +0xdf
```
