### PR TITLE
Replace attrs=id with attrs=__NONE

### DIFF
--- a/e2e/cases/4000_ngsi-v2/0001_ngsiv2_crud.test
+++ b/e2e/cases/4000_ngsi-v2/0001_ngsiv2_crud.test
@@ -253,7 +253,12 @@ ngsi list entities --type Product -attrs name,price --keyValues --verbose
 #
 # 1013 List Data Entity by ID
 #
-ngsi list entities --type Product -attrs id --verbose
+# Related issues:
+#  https://github.com/telefonicaid/fiware-orion/issues/3777
+#  https://github.com/lets-fiware/ngsi-go/issues/87
+#  https://github.com/FIWARE/tutorials.CRUD-Operations/issues/14
+#
+ngsi list entities --type Product -attrs __NONE --verbose
 
 ```
 [{"id":"urn:ngsi-ld:Product:001","type":"Product"},{"id":"urn:ngsi-ld:Product:002","type":"Product"},{"id":"urn:ngsi-ld:Product:003","type":"Product"},{"id":"urn:ngsi-ld:Product:004","type":"Product"},{"id":"urn:ngsi-ld:Product:005","type":"Product"},{"id":"urn:ngsi-ld:Product:006","type":"Product"},{"id":"urn:ngsi-ld:Product:007","type":"Product"},{"id":"urn:ngsi-ld:Product:008","type":"Product"},{"id":"urn:ngsi-ld:Product:009","type":"Product"},{"id":"urn:ngsi-ld:Product:010","type":"Product"},{"id":"urn:ngsi-ld:Product:011","type":"Product"},{"id":"urn:ngsi-ld:Product:012","type":"Product"}]

--- a/e2e/cases/4000_ngsi-v2/9001_attrs_NONE.test
+++ b/e2e/cases/4000_ngsi-v2/9001_attrs_NONE.test
@@ -1,0 +1,177 @@
+# MIT License
+#
+# Copyright (c) 2020-2021 Kazuhito Suda
+#
+# This file is part of NGSI Go
+#
+# https://github.com/lets-fiware/ngsi-go
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# Related issues:
+#  https://github.com/telefonicaid/fiware-orion/issues/3777
+#  https://github.com/lets-fiware/ngsi-go/issues/87
+#  https://github.com/FIWARE/tutorials.CRUD-Operations/issues/14 
+
+#
+# 0001 Create entity
+#
+ngsi create entity --data '{"id":"id001","A":{"type":"Text","value":"FIWARE"}}'
+
+```
+```
+
+#
+# 0002 List entities
+#
+ngsi list entities
+
+```
+id001
+```
+
+#
+# 0003 Count entities
+#
+ngsi list entities --count
+
+```
+1
+```
+
+#
+# 0004 List entities --verbose
+#
+ngsi list entities --verbose
+
+```
+[{"id":"id001","type":"Thing","A":{"type":"Text","value":"FIWARE","metadata":{}}}]
+```
+
+#
+# 0011 Create entity
+#
+ngsi create entity --data '{"id":"id002","type":"Event","A":{"type":"Text","value":"FIWARE"}}'
+
+```
+```
+
+#
+# 0012 List entities
+#
+ngsi list entities
+
+```
+id001
+id002
+```
+
+#
+# 0013 Count entities
+#
+ngsi list entities --count
+
+```
+2
+```
+
+#
+# 0014 List entities --verbose
+#
+ngsi list entities --pretty
+
+```
+[
+  {
+    "id": "id001",
+    "type": "Thing",
+    "A": {
+      "type": "Text",
+      "value": "FIWARE",
+      "metadata": {}
+    }
+  },
+  {
+    "id": "id002",
+    "type": "Event",
+    "A": {
+      "type": "Text",
+      "value": "FIWARE",
+      "metadata": {}
+    }
+  }
+]
+```
+
+#
+# 0021 Remove entities
+#
+ngsi rm --type Thing --run
+
+```
+1
+```
+
+#
+# 0022 List entities
+#
+ngsi list entities
+
+```
+id002
+```
+
+#
+# 0023 Count entities
+#
+ngsi list entities --count
+
+```
+1
+```
+
+#
+# 0024 Count entities
+#
+ngsi list entities --type Thing --count
+
+```
+0
+```
+
+#
+# 0025 Remove entities
+#
+ngsi rm --type Event --run
+
+```
+1
+```
+
+#
+# 0026 Count entities
+#
+ngsi list entities --count
+
+```
+0
+```
+

--- a/internal/ngsicmd/entities.go
+++ b/internal/ngsicmd/entities.go
@@ -51,7 +51,7 @@ func entitiesList(c *cli.Context) error {
 		return &ngsiCmdError{funcName, 2, err.Error(), err}
 	}
 
-	attrs := "id"
+	attrs := "__NONE"
 	if client.IsNgsiLd() {
 		attrs = ""
 	}
@@ -237,7 +237,7 @@ func entitiesCount(c *cli.Context) error {
 	} else {
 		v.Set("limit", "1")
 		v.Set("options", "count")
-		v.Set("attrs", "id")
+		v.Set("attrs", "__NONE")
 	}
 	client.SetQuery(v)
 

--- a/internal/ngsicmd/entities_test.go
+++ b/internal/ngsicmd/entities_test.go
@@ -63,6 +63,35 @@ func TestEntitiesListCountV2(t *testing.T) {
 	}
 }
 
+func TestEntitiesListCountV2AttrNone(t *testing.T) {
+	ngsi, set, app, buf := setupTest()
+
+	reqRes := MockHTTPReqRes{}
+	reqRes.Res.StatusCode = http.StatusOK
+	reqRes.Path = "/v2/entities"
+	reqRes.ResHeader = http.Header{"Fiware-Total-Count": []string{"9"}}
+	rawQuery := "attrs=__NONE&limit=1&options=count"
+	reqRes.RawQuery = &rawQuery
+	mock := NewMockHTTP()
+	mock.ReqRes = append(mock.ReqRes, reqRes)
+	ngsi.HTTP = mock
+	setupFlagString(set, "host,type")
+	setupFlagBool(set, "count")
+
+	c := cli.NewContext(app, set, nil)
+	_ = set.Parse([]string{"--host=orion", "--count"})
+
+	err := entitiesList(c)
+
+	if assert.NoError(t, err) {
+		actual := buf.String()
+		expected := "9\n"
+		assert.Equal(t, expected, actual)
+	} else {
+		t.FailNow()
+	}
+}
+
 func TestEntitiesListCountLD(t *testing.T) {
 	ngsi, set, app, buf := setupTest()
 
@@ -105,6 +134,36 @@ func TestEntitiesList(t *testing.T) {
 
 	c := cli.NewContext(app, set, nil)
 	_ = set.Parse([]string{"--host=orion", "--acceptJson"})
+	err := entitiesList(c)
+
+	if assert.NoError(t, err) {
+		actual := buf.String()
+		expected := "airqualityobserved_0\nairqualityobserved_1\nairqualityobserved_2\nairqualityobserved_3\nairqualityobserved_4\nairqualityobserved_5\nairqualityobserved_6\nairqualityobserved_7\nairqualityobserved_8\n"
+		assert.Equal(t, expected, actual)
+	} else {
+		t.FailNow()
+	}
+}
+
+func TestEntitiesListAttrNone(t *testing.T) {
+	ngsi, set, app, buf := setupTest()
+
+	reqRes := MockHTTPReqRes{}
+	reqRes.Res.StatusCode = http.StatusOK
+	reqRes.Path = "/v2/entities"
+	reqRes.ResHeader = http.Header{"Fiware-Total-Count": []string{"9"}}
+	reqRes.ResBody = []byte(`[{"id":"airqualityobserved_0","type":"AirQualityObserved","temperature":{"type":"Number","value":6.727447926,"metadata":{}}},{"id":"airqualityobserved_1","type":"AirQualityObserved","temperature":{"type":"Number","value":19.012560208,"metadata":{}}},{"id":"airqualityobserved_2","type":"AirQualityObserved","temperature":{"type":"Number","value":-3.196384014,"metadata":{}}},{"id":"airqualityobserved_3","type":"AirQualityObserved","temperature":{"type":"Number","value":7.992932652,"metadata":{}}},{"id":"airqualityobserved_4","type":"AirQualityObserved","temperature":{"type":"Number","value":-6.620346091,"metadata":{}}},{"id":"airqualityobserved_5","type":"AirQualityObserved","temperature":{"type":"Number","value":-16.634766746,"metadata":{}}},{"id":"airqualityobserved_6","type":"AirQualityObserved","temperature":{"type":"Number","value":20.263618173,"metadata":{}}},{"id":"airqualityobserved_7","type":"AirQualityObserved","temperature":{"type":"Number","value":14.285382467,"metadata":{}}},{"id":"airqualityobserved_8","type":"AirQualityObserved","temperature":{"type":"Number","value":6.998595286,"metadata":{}}}]`)
+	rawQuery := "attrs=__NONE&limit=100&offset=0&options=count"
+	reqRes.RawQuery = &rawQuery
+	mock := NewMockHTTP()
+	mock.ReqRes = append(mock.ReqRes, reqRes)
+	ngsi.HTTP = mock
+	setupFlagString(set, "host,type")
+	setupFlagBool(set, "acceptJson")
+
+	c := cli.NewContext(app, set, nil)
+	_ = set.Parse([]string{"--host=orion", "--acceptJson"})
+
 	err := entitiesList(c)
 
 	if assert.NoError(t, err) {

--- a/internal/ngsicmd/helper_test.go
+++ b/internal/ngsicmd/helper_test.go
@@ -174,6 +174,7 @@ type MockHTTPReqRes struct {
 	StatusCode int
 	ReqData    []byte
 	Path       string
+	RawQuery   *string
 }
 
 func AddReqRes(ngsi *ngsilib.NGSI, r MockHTTPReqRes) {
@@ -215,6 +216,11 @@ func (h *MockHTTP) Request(method string, url *url.URL, headers map[string]strin
 	}
 	if r.Path != "" && r.Path != url.Path {
 		return nil, nil, &ngsiCmdError{funcName, 3, "url error", nil}
+	}
+	if r.RawQuery != nil {
+		if *r.RawQuery != url.RawQuery {
+			return nil, nil, &ngsiCmdError{funcName, 4, "raw query error", nil}
+		}
 	}
 	if r.ResHeader != nil {
 		r.Res.Header = r.ResHeader

--- a/internal/ngsicmd/remove.go
+++ b/internal/ngsicmd/remove.go
@@ -74,7 +74,7 @@ func removeV2(c *cli.Context, ngsi *ngsilib.NGSI, client *ngsilib.Client) error 
 		v.Set("type", entityType)
 		v.Set("options", "count")
 		v.Set("limit", fmt.Sprintf("%d", limit))
-		v.Set("attrs", "id")
+		v.Set("attrs", "__NONE")
 		client.SetQuery(&v)
 
 		res, body, err := client.HTTPGet()

--- a/internal/ngsicmd/remove_test.go
+++ b/internal/ngsicmd/remove_test.go
@@ -72,6 +72,42 @@ func TestRemoveV2(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRemoveV2AttrNone(t *testing.T) {
+	ngsi, set, app, _ := setupTest()
+
+	reqRes1 := MockHTTPReqRes{}
+	reqRes1.Res.StatusCode = http.StatusOK
+	reqRes1.ResBody = []byte("[{\"id\":\"9f6c254ac4a6068bb276774e\",\"description\":\"ngsi source subscription\",\"subject\":{\"entities\":[{\"idPattern\":\".*\"}],\"condition\":{\"attrs\":[\"dateObserved\"]}},\"notification\":{\"timesSent\":28,\"lastNotification\":\"2020-09-24T07:30:02.00Z\",\"lastSuccess\":\"2020-09-24T07:30:02.00Z\",\"lastSuccessCode\":404,\"onlyChangedAttrs\":false,\"http\":{\"url\":\"https://ngsiproxy\"},\"attrsFormat\":\"keyValues\"},\"expires\":\"2020-09-24T07:49:13.00Z\",\"status\":\"inactive\"}]\n")
+	reqRes1.ResHeader = http.Header{"Fiware-Total-Count": []string{"1"}}
+	reqRes1.Path = "/v2/entities"
+	rawQuery := "attrs=__NONE&limit=100&options=count&type=Thing"
+	reqRes1.RawQuery = &rawQuery
+	reqRes2 := MockHTTPReqRes{}
+	reqRes2.Res.StatusCode = http.StatusOK
+	reqRes2.ReqData = []byte("{\"actionType\":\"delete\",\"entities\":[{\"description\":\"ngsi source subscription\",\"expires\":\"2020-09-24T07:49:13.00Z\",\"id\":\"9f6c254ac4a6068bb276774e\",\"notification\":{\"attrsFormat\":\"keyValues\",\"http\":{\"url\":\"https://ngsiproxy\"},\"lastNotification\":\"2020-09-24T07:30:02.00Z\",\"lastSuccess\":\"2020-09-24T07:30:02.00Z\",\"lastSuccessCode\":404,\"onlyChangedAttrs\":false,\"timesSent\":28},\"status\":\"inactive\",\"subject\":{\"condition\":{\"attrs\":[\"dateObserved\"]},\"entities\":[{\"idPattern\":\".*\"}]}}]}")
+	reqRes2.Path = "/v2/op/update"
+	reqRes3 := MockHTTPReqRes{}
+	reqRes3.Res.StatusCode = http.StatusOK
+	reqRes3.ResBody = []byte("[{\"id\":\"9f6c254ac4a6068bb276774e\",\"description\":\"ngsi source subscription\",\"subject\":{\"entities\":[{\"idPattern\":\".*\"}],\"condition\":{\"attrs\":[\"dateObserved\"]}},\"notification\":{\"timesSent\":28,\"lastNotification\":\"2020-09-24T07:30:02.00Z\",\"lastSuccess\":\"2020-09-24T07:30:02.00Z\",\"lastSuccessCode\":404,\"onlyChangedAttrs\":false,\"http\":{\"url\":\"https://ngsiproxy\"},\"attrsFormat\":\"keyValues\"},\"expires\":\"2020-09-24T07:49:13.00Z\",\"status\":\"inactive\"}]\n")
+	reqRes3.ResHeader = http.Header{"Fiware-Total-Count": []string{"0"}}
+	reqRes3.Path = "/v2/entities"
+
+	mock := NewMockHTTP()
+	mock.ReqRes = append(mock.ReqRes, reqRes1)
+	mock.ReqRes = append(mock.ReqRes, reqRes2)
+	mock.ReqRes = append(mock.ReqRes, reqRes3)
+	ngsi.HTTP = mock
+
+	setupFlagString(set, "host,type")
+	setupFlagBool(set, "run")
+	c := cli.NewContext(app, set, nil)
+	_ = set.Parse([]string{"--host=orion", "--type=Thing", "--run"})
+
+	err := remove(c)
+
+	assert.NoError(t, err)
+}
+
 func TestRemoveLD(t *testing.T) {
 	ngsi, set, app, _ := setupTest()
 

--- a/script/tutorial.sh
+++ b/script/tutorial.sh
@@ -76,6 +76,17 @@ case "${command}" in
         ./run.sh cases/6000_time_series/1000_comet/0002_create_historical_data.test
         ./run.sh cases/6000_time_series/2000_quantumleap/0003_create_historical_data.test
         ;;
+    "up")
+        make build
+        cd e2e
+        if [ ! "$(docker-compose ps -a | wc -l)" = "2" ]; then
+            make down
+        fi
+        make build
+        make rmi
+        make up
+        ./run.sh cases/0000_prepare/
+        ;;
     "stop")
         cd e2e
         make down


### PR DESCRIPTION
## Proposed changes

This PR changes a way to get a list of Entity IDs. It replaces `attrs=id` with `attrs=__NONE` in `GET /v2/entties`.

Fixed :  https://github.com/lets-fiware/ngsi-go/issues/87

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Related issues:
-  https://github.com/telefonicaid/fiware-orion/issues/3777
-  https://github.com/FIWARE/tutorials.CRUD-Operations/issues/14