### PR TITLE
Tentatively fix unmarshal error

### DIFF
--- a/internal/ngsicmd/types.go
+++ b/internal/ngsicmd/types.go
@@ -160,6 +160,11 @@ func typesListLd(c *cli.Context, ngsi *ngsilib.NGSI, client *ngsilib.Client) err
 	} else if c.IsSet("json") {
 		fmt.Fprintln(ngsi.StdWriter, string(body))
 	} else {
+		// https://github.com/FIWARE/context.Orion-LD/issues/732
+		if len(body) == 2 && string(body) == "[]" { // tentatively
+			fmt.Fprintln(ngsi.StdWriter, "{}")
+			return nil
+		}
 		var list entityTypeList
 		err := ngsilib.JSONUnmarshal(body, &list)
 		if err != nil {

--- a/internal/ngsicmd/types_test.go
+++ b/internal/ngsicmd/types_test.go
@@ -90,6 +90,32 @@ func TestTypesListLD(t *testing.T) {
 	}
 }
 
+func TestTypesListLDEmpty(t *testing.T) {
+	ngsi, set, app, buf := setupTest()
+
+	reqRes := MockHTTPReqRes{}
+	reqRes.Res.StatusCode = http.StatusOK
+	reqRes.Path = "/ngsi-ld/v1/types"
+	reqRes.ResBody = []byte(`[]`)
+	mock := NewMockHTTP()
+	mock.ReqRes = append(mock.ReqRes, reqRes)
+	ngsi.HTTP = mock
+
+	setupFlagString(set, "host,link")
+	c := cli.NewContext(app, set, nil)
+	_ = set.Parse([]string{"--host=orion-ld", "--link=etsi"})
+
+	err := typesList(c)
+
+	if assert.NoError(t, err) {
+		actual := buf.String()
+		expected := "{}\n"
+		assert.Equal(t, expected, actual)
+	} else {
+		t.FailNow()
+	}
+}
+
 func TestTypesListErrorInitCmd(t *testing.T) {
 	_, set, app, _ := setupTest()
 


### PR DESCRIPTION
## Proposed changes

This PR tentatively fixes unmarshal error in types command for Orion-LD.

```
$ ngsi list --host orion-ld types
typesListLd004 json: cannot unmarshal array into Go value of type ngsicmd.entityTypeList Field: (1) []
```

NGSI-LD spec specifies that GET /ngsi-ld/v1/types returns a EntityTypeList type, unless details=true is specified.
But it returns an empty JSONarray when EntityTypeList is empty.

```
$ curl orion-ld:1026/ngsi-ld/v1/types
[]
```

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
