### PR TITLE
Set Accept Header to application/json in batch request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NGSI Go v0.8.2-next
 
--   Hardening: Add skipForwarding option for Orion
+-   Fix: Set Accept Header to application/json in batch request
+-   Hardening: Add skipForwarding option for Orion (#150)
 -   Fix: Fix message in cp command (#149)
 -   Update: Update test process (#148)
 -   Update: Update Orion version to 3.1.0 (#146)

--- a/e2e/cases/2000_convenience/0203_cp_command_ldld.test
+++ b/e2e/cases/2000_convenience/0203_cp_command_ldld.test
@@ -48,6 +48,7 @@ ngsi upsert entities --link ctx \
 ]'
 
 ```
+["urn:ngsi-ld:TemperatureSensor:001","urn:ngsi-ld:TemperatureSensor:002","urn:ngsi-ld:TemperatureSensor:003","urn:ngsi-ld:TemperatureSensor:004","urn:ngsi-ld:TemperatureSensor:005","urn:ngsi-ld:TemperatureSensor:006"]
 ```
 
 #
@@ -274,6 +275,7 @@ ngsi upsert entities --link ctx \
 ]'
 
 ```
+["urn:ngsi-ld:TemperatureSensor:001","urn:ngsi-ld:TemperatureSensor:002","urn:ngsi-ld:TemperatureSensor:003","urn:ngsi-ld:TemperatureSensor:004","urn:ngsi-ld:TemperatureSensor:005","urn:ngsi-ld:TemperatureSensor:006"]
 ```
 
 #
@@ -290,6 +292,7 @@ ngsi upsert entities --link ctx \
 ]'
 
 ```
+["urn:ngsi-ld:Building:001","urn:ngsi-ld:Building:002","urn:ngsi-ld:Building:003","urn:ngsi-ld:Building:004","urn:ngsi-ld:Building:005","urn:ngsi-ld:Building:006"]
 ```
 
 #

--- a/e2e/cases/5000_ngsi-ld/0030_upsert_entities.test
+++ b/e2e/cases/5000_ngsi-ld/0030_upsert_entities.test
@@ -36,10 +36,10 @@ REGEX(.*)
 ```
 
 #
-# 0001 Create entities with link
+# 0001 Upsert entities with link
 #
 
-ngsi create --host orion-ld entities --link ctx \
+ngsi upsert --host orion-ld entities --link ctx \
 --data '[
 {"id":"urn:ngsi-ld:TemperatureSensor:001","type":"TemperatureSensor","category":{"type":"Property","value":"sensor"},"temperature":{"type":"Property","value":25,"unitCode":"CEL"}},
 {"id":"urn:ngsi-ld:TemperatureSensor:002","type":"TemperatureSensor","category":{"type":"Property","value":"sensor"},"temperature":{"type":"Property","value":26,"unitCode":"CEL"}},
@@ -60,10 +60,10 @@ REGEX(.*)
 ```
 
 #
-# 0012 Create entities with context
+# 0012 Upsert entities with context
 #
 
-ngsi create --host orion-ld entities --context ctx \
+ngsi upsert --host orion-ld entities --context ctx \
 --data '[
 {"id":"urn:ngsi-ld:TemperatureSensor:001","type":"TemperatureSensor","category":{"type":"Property","value":"sensor"},"temperature":{"type":"Property","value":25,"unitCode":"CEL"}},
 {"id":"urn:ngsi-ld:TemperatureSensor:002","type":"TemperatureSensor","category":{"type":"Property","value":"sensor"},"temperature":{"type":"Property","value":26,"unitCode":"CEL"}},

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     command: -dbhost mongo
 
   orion-ld:
-    image: fiware/orion-ld:0.7-PRE-107
+    image: fiware/orion-ld:v0.8.1
     depends_on:
       - mongo
     command: -dbhost mongo -db orionld

--- a/internal/ngsicmd/batch.go
+++ b/internal/ngsicmd/batch.go
@@ -84,6 +84,7 @@ func batchCreate(c *cli.Context, ngsi *ngsilib.NGSI, client *ngsilib.Client) err
 	client.SetPath("/entityOperations/create")
 
 	client.SetContentType()
+	client.SetAcceptJSON()
 
 	b, err := readAll(c, ngsi)
 	if err != nil {
@@ -120,6 +121,7 @@ func batchUpdate(c *cli.Context, ngsi *ngsilib.NGSI, client *ngsilib.Client) err
 	client.SetQuery(v)
 
 	client.SetContentType()
+	client.SetAcceptJSON()
 
 	b, err := readAll(c, ngsi)
 	if err != nil {
@@ -153,6 +155,7 @@ func batchUpsert(c *cli.Context, ngsi *ngsilib.NGSI, client *ngsilib.Client) err
 	client.SetQuery(v)
 
 	client.SetContentType()
+	client.SetAcceptJSON()
 
 	b, err := readAll(c, ngsi)
 	if err != nil {


### PR DESCRIPTION
## Proposed changes

This PR sets Accept Header to `application/json` in batch create/update/upsert request for Orion-ld

Related issues:  https://github.com/FIWARE/context.Orion-LD/issues/776, https://github.com/FIWARE/context.Orion-LD/issues/885, https://github.com/FIWARE/tutorials.CRUD-Operations/pull/17

The response is corrupted when setting Accept Header to `applicationld+json` or `*/*` in batch create or upsert for Orion-ld 0.8.0.
It Should be set Accept Header to `application/json`.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
