### PR TITLE
Fix not to stay messages in buffer for Stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NGSI Go v0.x.x
 
--   Fix: Fix cache parameter
+-   Fix: Fix not to stay messages in buffer for Stdout at receiver command
+-   Fix: Fix cache parameter (#154)
 
 ## NGSI Go v0.8.3 - June 12, 2021
 

--- a/internal/ngsicmd/receiver.go
+++ b/internal/ngsicmd/receiver.go
@@ -162,6 +162,7 @@ func receiverHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		fmt.Fprintf(receiverGlobal.ngsi.StdWriter, "%s\n", string(b))
+		receiverGlobal.ngsi.StdoutFlush()
 	}
 	w.WriteHeader(status)
 }


### PR DESCRIPTION
## Proposed changes

This PR fixes not to stay messages in buffer for Stdout at receiver command.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
