### PR TITLE
Add PreviousArgs sub-cmd in settings

### DIFF
--- a/docs/management/settings.md
+++ b/docs/management/settings.md
@@ -3,11 +3,14 @@
 -   [List current settings](#list-current-settings)
 -   [Delete currnet settings](#delete-currnet-settings)
 -   [Clear currnet settings](#clear-currnet-settings)
-
+-   [Set previous args mode](#set-previousargs-mode)
 
 <a name="list-current-settings"></a>
 
 ## List current settings
+
+This command allows you to print currnet previous args. If you get confused about a behavior of NGSI Go,
+please run this command to check previous values. You can clear previous values with `ngsi settings clear`.
 
 ```console
 ngsi settings list [options]
@@ -74,12 +77,40 @@ ngsi settings delete --items service,syslog
 
 ## Clear currnet settings
 
+This command allows you to clear currnet previous args. If you get confused about a behavior of NGSI Go,
+please run `ngsi settings list` command to check previous values. You can clear previous values with this
+command.
+
 ```console
 ngsi settings clear [options]
 ```
 
 ### Options
 
-| Options                 | Description                                 |
-| ----------------------- | ------------------------------------------- |
-| --help                  | show help (default: false)                  |
+| Options | Description                |
+| ------- | -------------------------- |
+| --help  | show help (default: false) |
+
+<a name="set-previousargs-mode"></a>
+
+## Set previous args mode
+
+This command allows you to turns on or off the previous args mode. When multiple NGSI Go are run at the same time,
+there is a conflict in writing to the config file. E.g. you run NGSI Go on an interactive shell and run one in
+background as a batch process at same time. As a result, you may access an unexpected host.
+
+The previous agrs are not stored in the config file when the PreviousArgs mode is off or you run NGSI Go with
+`-B` (`--batch`) option. I recommend to use -Boption and specify explicitly a host, FIWARE Service and FIWARE
+ServicePath when NGSI Go is used in a shell script.
+
+```
+ngsi settings previousArgs [options]
+```
+
+### Options
+
+| Options   | Description                    |
+| --------- | ------------------------------ |
+| --off, -d | off (disable) (default: false) |
+| --on, -e  | on (enable) (default: false)   |
+| --help    | show help (default: false)     |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -234,27 +234,28 @@ ngsi [global options] command [common options] sub-command [options]
 
 ### Management command
 
-| command                              | sub-command                                                | Description     |
-| ------------------------------------ | ---------------------------------------------------------- | --------------- |
-| [broker](./management/broker.md)     | [list](./management/broker.md#list-brokers)                | list brokers    |
-|                                      | [get](./management/broker.md#get-broker)                   | get broker      |
-|                                      | [add](./management/broker.md#add-broker)                   | add broker      |
-|                                      | [update](./management/broker.md#update-broker)             | update broker   |
-|                                      | [delete](./management/broker.md#delete-broker)             | delete broker   |
-| [context](./management/context.md)   | [list](./management/context.md#list-contexts)              | list @context   |
-|                                      | [add](./management/context.md#add-context)                 | add @context    |
-|                                      | [update](./management/context.md#update-context)           | udpate @context |
-|                                      | [delete](./management/context.md#delete-context)           | delete @context |
-|                                      | [server](./management/context.md#serve-context)            | Serve @context  |
-| [settings](./management/settings.md) | [list](./management/settings.md#list-current-settings)     | list settings   |
-|                                      | [delete](./management/settings.md#delete-currnet-settings) | delete settings |
-|                                      | [clear](./management/settings.md#clear-currnet-settings)   | clear settings  |
-| [server](./management/server.md)     | [list](./management/server.md#list-servers)                | list servers    |
-|                                      | [get](./management/server.md#get-server)                   | get server      |
-|                                      | [add](./management/server.md#add-server)                   | add server      |
-|                                      | [update](./management/server.md#update-server)             | update server   |
-|                                      | [delete](./management/server.md#delete-server)             | delete server   |
-| [token](./management/token.md)       | -                                                          | manage token    |
+| command                              | sub-command                                                    | Description            |
+| ------------------------------------ | -------------------------------------------------------------- | ---------------------- |
+| [broker](./management/broker.md)     | [list](./management/broker.md#list-brokers)                    | list brokers           |
+|                                      | [get](./management/broker.md#get-broker)                       | get broker             |
+|                                      | [add](./management/broker.md#add-broker)                       | add broker             |
+|                                      | [update](./management/broker.md#update-broker)                 | update broker          |
+|                                      | [delete](./management/broker.md#delete-broker)                 | delete broker          |
+| [context](./management/context.md)   | [list](./management/context.md#list-contexts)                  | list @context          |
+|                                      | [add](./management/context.md#add-context)                     | add @context           |
+|                                      | [update](./management/context.md#update-context)               | udpate @context        |
+|                                      | [delete](./management/context.md#delete-context)               | delete @context        |
+|                                      | [server](./management/context.md#serve-context)                | Serve @context         |
+| [settings](./management/settings.md) | [list](./management/settings.md#list-current-settings)         | list settings          |
+|                                      | [delete](./management/settings.md#delete-currnet-settings)     | delete settings        |
+|                                      | [clear](./management/settings.md#clear-currnet-settings)       | clear settings         |
+|                                      | [previousArgs](./management/settings.md#set-previousargs-mode) | set previous args mode |
+| [server](./management/server.md)     | [list](./management/server.md#list-servers)                    | list servers           |
+|                                      | [get](./management/server.md#get-server)                       | get server             |
+|                                      | [add](./management/server.md#add-server)                       | add server             |
+|                                      | [update](./management/server.md#update-server)                 | update server          |
+|                                      | [delete](./management/server.md#delete-server)                 | delete server          |
+| [token](./management/token.md)       | -                                                              | manage token           |
 
 <a name="global-options"></a>
 

--- a/e2e/cases/3000_management/0302_settings_command_previous_args.test
+++ b/e2e/cases/3000_management/0302_settings_command_previous_args.test
@@ -25,32 +25,7 @@
 # SOFTWARE.
 
 #
-# 0001 ngsi settings
-#
-ngsi settings
-
-```
-NAME:
-   ngsi settings - manage settings
-
-USAGE:
-   ngsi settings command [command options] [arguments...]
-
-COMMANDS:
-   list          List settings
-   delete        Delete setting
-   clear         Clear settings
-   previousArgs  Set PreviousArgs mode
-   help, h       Shows a list of commands or help for one command
-
-OPTIONS:
-   --help         show help (default: false)
-   --version, -v  print the version (default: false)
-   
-```
-
-#
-# 0010 ngsi settings clear
+# 0001 ngsi settings clear
 #
 ngsi settings clear
 
@@ -58,7 +33,15 @@ ngsi settings clear
 ```
 
 #
-# 0011 ngsi settings list
+# 0011 ngsi settings
+#
+ngsi settings previousArgs --on
+
+```
+```
+
+#
+# 0012 ngsi settings list
 #
 ngsi settings list
 
@@ -66,7 +49,7 @@ ngsi settings list
 ```
 
 #
-# 0012 ngsi version --host orion
+# 0013 ngsi version --host orion
 #
 ngsi version --host orion
 
@@ -96,7 +79,7 @@ ngsi version --host orion
 ```
 
 #
-# 0013 ngsi settings list
+# 0014 ngsi settings list
 #
 ngsi settings list
 
@@ -105,29 +88,55 @@ Host: orion
 ```
 
 #
-# 0014 ngsi settings clear
+# 0015 ngsi version --host wirecloud --pretty
 #
-ngsi settings clear
+ngsi version --host wirecloud --pretty
 
 ```
+{
+  "ApplicationMashup": "REGEX(.*)",
+  "ComponentManagement": "REGEX(.*)",
+  "DashboardManagement": "REGEX(.*)",
+  "FIWARE": "REGEX(.*)",
+  "FullscreenWidget": "REGEX(.*)",
+  "NGSI": "REGEX(.*)",
+  "OAuth2Provider": "REGEX(.*)",
+  "ObjectStorage": "REGEX(.*)",
+  "StyledElements": "REGEX(.*)",
+  "Wirecloud": "REGEX(.*)"
+}
 ```
 
 #
-# 0015 ngsi settings list
+# 0016 ngsi settings list
 #
 ngsi settings list
 
 ```
+Host: wirecloud
 ```
-#
-# 0016 print $orion
-#
-print $orion
 
 #
-# 0017 ngsi version --host $orion
+# 0021 ngsi settings previousArgs --off
 #
-ngsi version --host $orion
+ngsi settings previousArgs --off
+
+```
+```
+
+#
+# 0022 ngsi settings list
+#
+ngsi settings list
+
+```
+PreviousArgs off
+```
+
+#
+# 0023 ngsi version --host orion
+#
+ngsi version --host orion
 
 ```
 {
@@ -155,17 +164,54 @@ ngsi version --host $orion
 ```
 
 #
-# 0018 ngsi settings list
+# 0024 ngsi settings list
 #
 ngsi settings list
 
 ```
+PreviousArgs off
 ```
 
 #
-# 9999 Clean up
+# 0025 ngsi version --host wirecloud --pretty
+#
+ngsi version --host wirecloud --pretty
+
+```
+{
+  "ApplicationMashup": "REGEX(.*)",
+  "ComponentManagement": "REGEX(.*)",
+  "DashboardManagement": "REGEX(.*)",
+  "FIWARE": "REGEX(.*)",
+  "FullscreenWidget": "REGEX(.*)",
+  "NGSI": "REGEX(.*)",
+  "OAuth2Provider": "REGEX(.*)",
+  "ObjectStorage": "REGEX(.*)",
+  "StyledElements": "REGEX(.*)",
+  "Wirecloud": "REGEX(.*)"
+}
+```
+
+#
+# 0026 ngsi settings list
+#
+ngsi settings list
+
+```
+PreviousArgs off
+```
+#
+# 9998 ngsi settings clear
 #
 ngsi settings clear
+
+```
+```
+
+#
+# 9999 ngsi settings previousArgs --on
+#
+ngsi settings previousArgs --on
 
 ```
 ```

--- a/internal/ngsicmd/flags.go
+++ b/internal/ngsicmd/flags.go
@@ -143,6 +143,16 @@ var (
 		Name:  "clearText",
 		Usage: "show obfuscated items as clear text",
 	}
+	onFlag = &cli.BoolFlag{
+		Name:    "on",
+		Aliases: []string{"e"},
+		Usage:   "on (enable)",
+	}
+	offFlag = &cli.BoolFlag{
+		Name:    "off",
+		Aliases: []string{"d"},
+		Usage:   "off (disable)",
+	}
 )
 
 // Common flags for copy command

--- a/internal/ngsicmd/ngsi.go
+++ b/internal/ngsicmd/ngsi.go
@@ -758,6 +758,17 @@ var settingsCmd = cli.Command{
 				return settingsClear(c)
 			},
 		},
+		{
+			Name:  "previousArgs",
+			Usage: "Set PreviousArgs mode",
+			Flags: []cli.Flag{
+				offFlag,
+				onFlag,
+			},
+			Action: func(c *cli.Context) error {
+				return settingsPreviousArgs(c)
+			},
+		},
 	},
 }
 

--- a/internal/ngsicmd/ngsi_test.go
+++ b/internal/ngsicmd/ngsi_test.go
@@ -86,6 +86,7 @@ func TestNGSICommand(t *testing.T) {
 		{args: []string{"settings", "list"}, rc: 1},
 		{args: []string{"settings", "clear"}, rc: 1},
 		{args: []string{"settings", "delete"}, rc: 1},
+		{args: []string{"settings", "previousArgs"}, rc: 1},
 		{args: []string{"append", "attrs", "--id", "abc"}, rc: 1},
 		{args: []string{"create", "entities"}, rc: 1},
 		{args: []string{"create", "entity"}, rc: 1},

--- a/internal/ngsicmd/settings.go
+++ b/internal/ngsicmd/settings.go
@@ -49,6 +49,9 @@ func settingsList(c *cli.Context) error {
 
 	all := c.Bool("all")
 
+	if !d.UsePreviousArgs {
+		fmt.Fprintln(ngsi.StdWriter, "PreviousArgs off")
+	}
 	printItem(ngsi.StdWriter, "Host", d.Host, all)
 	printItem(ngsi.StdWriter, "FIWARE-Service", d.Tenant, all)
 	printItem(ngsi.StdWriter, "FIWARE-ServicePath", d.Scope, all)
@@ -135,6 +138,41 @@ func settingsClear(c *cli.Context) error {
 	err = ngsi.SavePreviousArgs()
 	if err != nil {
 		return &ngsiCmdError{funcName, 2, err.Error(), err}
+	}
+
+	return nil
+}
+
+func settingsPreviousArgs(c *cli.Context) error {
+	const funcName = "settingsPreviousArgs"
+
+	ngsi, err := initCmd(c, funcName, false)
+	if err != nil {
+		return &ngsiCmdError{funcName, 1, err.Error(), err}
+	}
+
+	on := c.Bool("on")
+	off := c.Bool("off")
+
+	if on == off {
+		return &ngsiCmdError{funcName, 2, "specify either on or off", nil}
+	}
+
+	d := ngsi.GetPreviousArgs()
+
+	d.UsePreviousArgs = on
+	d.Host = ""
+	d.Tenant = ""
+	d.Scope = ""
+	d.Token = ""
+	d.Syslog = ""
+	d.Stderr = ""
+	d.Logfile = ""
+	d.Loglevel = ""
+
+	err = ngsi.SavePreviousArgs()
+	if err != nil {
+		return &ngsiCmdError{funcName, 3, err.Error(), err}
 	}
 
 	return nil

--- a/internal/ngsilib/config.go
+++ b/internal/ngsilib/config.go
@@ -210,10 +210,7 @@ func (ngsi *NGSI) GetPreviousArgs() *Settings {
 
 // SavePreviousArgs is ...
 func (ngsi *NGSI) SavePreviousArgs() error {
-	if ngsi.PreviousArgs.UsePreviousArgs {
-		return ngsi.saveConfigFile()
-	}
-	return nil
+	return ngsi.saveConfigFile()
 }
 
 func migration(config *NgsiConfig) {

--- a/internal/ngsilib/config_test.go
+++ b/internal/ngsilib/config_test.go
@@ -389,6 +389,8 @@ func TestSavePreviousArgs(t *testing.T) {
 
 func TestSavePreviousArgsNoSave(t *testing.T) {
 	ngsi := testNgsiLibInit()
+	filename := ""
+	ngsi.ConfigFile.SetFileName(&filename)
 	ngsi.PreviousArgs.UsePreviousArgs = false
 
 	err := ngsi.SavePreviousArgs()

--- a/internal/ngsilib/new_client.go
+++ b/internal/ngsilib/new_client.go
@@ -173,7 +173,7 @@ func (ngsi *NGSI) NewClient(name string, cmdFlags *CmdFlags, isHTTPVerb bool) (c
 		return nil, &LibError{funcName, 11, err.Error(), err}
 	}
 
-	if ngsi.Updated {
+	if ngsi.Updated && ngsi.GetPreviousArgs().UsePreviousArgs {
 		if _, ok := ngsi.serverList[ngsi.PreviousArgs.Host]; !ok {
 			ngsi.PreviousArgs.Host = ""
 			ngsi.PreviousArgs.Tenant = ""


### PR DESCRIPTION
## Proposed changes

This PR adds the `previousArgs` sub-cmd in settings command.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
