### PR TITLE
Use refresh token to renew token for Keyrock (#128)

### DIFF
--- a/internal/ngsilib/token_token_proxy_test.go
+++ b/internal/ngsilib/token_token_proxy_test.go
@@ -67,6 +67,35 @@ func TestRequestTokenTokenproxy(t *testing.T) {
 	}
 }
 
+func TestRequestTokenTokenproxyRefresh(t *testing.T) {
+	ngsi := testNgsiLibInit()
+
+	ngsi.tokenList = tokenInfoList{}
+	filename := ""
+	ngsi.CacheFile = &MockIoLib{filename: &filename}
+	ngsi.LogWriter = &bytes.Buffer{}
+	reqRes := MockHTTPReqRes{}
+	reqRes.Res.StatusCode = http.StatusOK
+	reqRes.ResBody = []byte(`{"access_token": "ad5252cd520cnaddacdc5d2e63899f0cdcf946f3", "expires_in": 3599, "refresh_token": "03e33a311e03317b390956729bcac2794b695670", "scope": [ "bearer" ], "token_type": "Bearer" }`)
+	mock := NewMockHTTP()
+	mock.ReqRes = append(mock.ReqRes, reqRes)
+	ngsi.HTTP = mock
+	ngsi.tokenList["token1"] = TokenInfo{}
+	ngsi.tokenList["token2"] = TokenInfo{}
+
+	client := &Client{Server: &Server{ServerHost: "http://orion/", IdmType: CTokenproxy, IdmHost: "http://idm", Username: "fiware", Password: "1234", ClientID: "0000", ClientSecret: "1111"}}
+	idm := &idmTokenProxy{}
+	tokenInfo := &TokenInfo{RefreshToken: "refresh"}
+
+	actual, err := idm.requestToken(ngsi, client, tokenInfo)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, CTokenproxy, actual.Type)
+		expected := "ad5252cd520cnaddacdc5d2e63899f0cdcf946f3"
+		assert.Equal(t, expected, actual.Oauth.AccessToken)
+	}
+}
+
 func TestRequestTokenTokenproxyErrorUser(t *testing.T) {
 	ngsi := testNgsiLibInit()
 
@@ -126,35 +155,6 @@ func TestRequestTokenTokenproxyErrorHTTP(t *testing.T) {
 	}
 }
 
-func TestRequestTokenTokenproxyErrorHTTPStatus(t *testing.T) {
-	ngsi := testNgsiLibInit()
-
-	ngsi.tokenList = tokenInfoList{}
-	filename := ""
-	ngsi.CacheFile = &MockIoLib{filename: &filename}
-	ngsi.LogWriter = &bytes.Buffer{}
-	reqRes := MockHTTPReqRes{}
-	reqRes.Res.StatusCode = http.StatusBadRequest
-	reqRes.ResBody = []byte(`bad request`)
-	mock := NewMockHTTP()
-	mock.ReqRes = append(mock.ReqRes, reqRes)
-	ngsi.HTTP = mock
-	ngsi.tokenList["token1"] = TokenInfo{}
-	ngsi.tokenList["token2"] = TokenInfo{}
-
-	client := &Client{Server: &Server{ServerHost: "http://orion/", IdmType: CTokenproxy, IdmHost: "http://idm", Username: "fiware", Password: "1234", ClientID: "0000", ClientSecret: "1111"}}
-	idm := &idmTokenProxy{}
-	tokenInfo := &TokenInfo{}
-
-	_, err := idm.requestToken(ngsi, client, tokenInfo)
-
-	if assert.Error(t, err) {
-		ngsiErr := err.(*LibError)
-		assert.Equal(t, 3, ngsiErr.ErrNo)
-		assert.Equal(t, "error  bad request", ngsiErr.Message)
-	}
-}
-
 func TestRequestTokenTokenproxyErrorUnmarshal(t *testing.T) {
 	ngsi := testNgsiLibInit()
 
@@ -179,9 +179,67 @@ func TestRequestTokenTokenproxyErrorUnmarshal(t *testing.T) {
 
 	if assert.Error(t, err) {
 		ngsiErr := err.(*LibError)
-		assert.Equal(t, 4, ngsiErr.ErrNo)
+		assert.Equal(t, 3, ngsiErr.ErrNo)
 		actual := "json: cannot unmarshal string into Go value of type ngsilib.OauthToken Field: (14) \"access_token\": \"ad5252cd520c"
 		assert.Equal(t, actual, ngsiErr.Message)
+	}
+}
+
+func TestRequestTokenTokenproxyErrorHTTPStatus(t *testing.T) {
+	ngsi := testNgsiLibInit()
+
+	ngsi.tokenList = tokenInfoList{}
+	filename := ""
+	ngsi.CacheFile = &MockIoLib{filename: &filename}
+	ngsi.LogWriter = &bytes.Buffer{}
+	reqRes := MockHTTPReqRes{}
+	reqRes.Res.StatusCode = http.StatusBadRequest
+	reqRes.ResBody = []byte(`bad request`)
+	mock := NewMockHTTP()
+	mock.ReqRes = append(mock.ReqRes, reqRes)
+	ngsi.HTTP = mock
+	ngsi.tokenList["token1"] = TokenInfo{}
+	ngsi.tokenList["token2"] = TokenInfo{}
+
+	client := &Client{Server: &Server{ServerHost: "http://orion/", IdmType: CTokenproxy, IdmHost: "http://idm", Username: "fiware", Password: "1234", ClientID: "0000", ClientSecret: "1111"}}
+	idm := &idmTokenProxy{}
+	tokenInfo := &TokenInfo{}
+
+	_, err := idm.requestToken(ngsi, client, tokenInfo)
+
+	if assert.Error(t, err) {
+		ngsiErr := err.(*LibError)
+		assert.Equal(t, 4, ngsiErr.ErrNo)
+		assert.Equal(t, "error  bad request", ngsiErr.Message)
+	}
+}
+
+func TestRequestTokenTokenproxyErrorHTTPStatusUnauthorized(t *testing.T) {
+	ngsi := testNgsiLibInit()
+
+	ngsi.tokenList = tokenInfoList{}
+	filename := ""
+	ngsi.CacheFile = &MockIoLib{filename: &filename}
+	ngsi.LogWriter = &bytes.Buffer{}
+	reqRes := MockHTTPReqRes{}
+	reqRes.Res.StatusCode = http.StatusUnauthorized
+	reqRes.ResBody = []byte(`Unauthorized`)
+	mock := NewMockHTTP()
+	mock.ReqRes = append(mock.ReqRes, reqRes)
+	ngsi.HTTP = mock
+	ngsi.tokenList["token1"] = TokenInfo{}
+	ngsi.tokenList["token2"] = TokenInfo{}
+
+	client := &Client{Server: &Server{ServerHost: "http://orion/", IdmType: CTokenproxy, IdmHost: "http://idm", Username: "fiware", Password: "1234", ClientID: "0000", ClientSecret: "1111"}}
+	idm := &idmTokenProxy{}
+	tokenInfo := &TokenInfo{}
+
+	_, err := idm.requestToken(ngsi, client, tokenInfo)
+
+	if assert.Error(t, err) {
+		ngsiErr := err.(*LibError)
+		assert.Equal(t, 4, ngsiErr.ErrNo)
+		assert.Equal(t, "error  Unauthorized", ngsiErr.Message)
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

This PR makes NGSI Go use a refresh token to renew a token for Keyrock.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
