### PR TITLE
Fix EOF error when ngsi-go-config.json is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NGSI Go v0.8.4-next
 
+-   Fix: Fix EOF error when ngsi-go-config.json is empty (#175)
 -   Hardening: Add replace option in regproxy (#174)
 -   Hardening: Support WSO2 (#173)
 -   Documentation: Update documentation (#172)

--- a/internal/ngsilib/config.go
+++ b/internal/ngsilib/config.go
@@ -97,9 +97,11 @@ func initConfig(ngsi *NGSI, io IoLib) error {
 		}
 
 		ngsiConfig := NgsiConfig{}
-		err = JSONUnmarshal(b, &ngsiConfig)
-		if err != nil {
-			return &LibError{funcName, 4, err.Error(), err}
+		if len(b) > 0 {
+			err = JSONUnmarshal(b, &ngsiConfig)
+			if err != nil {
+				return &LibError{funcName, 4, err.Error(), err}
+			}
 		}
 
 		ngsi.configVresion = ngsiConfig.Version

--- a/internal/ngsilib/config_test.go
+++ b/internal/ngsilib/config_test.go
@@ -43,6 +43,7 @@ func TestNgsiIntiConfig(t *testing.T) {
 
 	filename := ""
 	err := ngsi.InitConfig(&filename)
+
 	assert.NoError(t, err)
 }
 
@@ -64,6 +65,20 @@ func TestIntiConfigBrokerList(t *testing.T) {
 	broker := &Server{ServerHost: "http://orion"}
 	ngsi.serverList["orion"] = broker
 	ngsi.configVresion = "1"
+
+	err := initConfig(ngsi, ngsi.ConfigFile)
+
+	assert.NoError(t, err)
+}
+
+func TestIntiConfigBrokerEOF(t *testing.T) {
+	ngsi := testNgsiLibInit()
+	filename := "config.json"
+	ngsi.ConfigFile = &MockIoLib{}
+	ngsi.ConfigFile.SetFileName(&filename)
+	ngsi.CacheFile = &MockIoLib{}
+	ngsi.CacheFile.SetFileName(&filename)
+	ngsi.FileReader = &MockFileLib{readFile: []byte("")}
 
 	err := initConfig(ngsi, ngsi.ConfigFile)
 


### PR DESCRIPTION
## Proposed changes

This PR fixes EOF error when ngsi-go-config.json is empty.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
