### PR TITLE
Set default FIWARE Service Path to '/' in rm command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NGSI Go v0.8.4-next
 
+-   Improve: Set default FIWARE Service Path to "/" in rm command (#179)
 -   Hardening: Support Kong (#178)
 -   Hardening: Add insecureSkipVerify option (#177)
 -   Fix: Fix URL path join (#176)

--- a/internal/ngsicmd/remove.go
+++ b/internal/ngsicmd/remove.go
@@ -67,6 +67,9 @@ func remove(c *cli.Context) error {
 		if c.IsSet("link") {
 			return &ngsiCmdError{funcName, 5, "can't specify --link option on NGSIv2", nil}
 		}
+		if client.Scope == "" {
+			client.Headers["Fiware-ServicePath"] = "/"
+		}
 		if c.Bool("ngsiV1") {
 			f = removeV1
 		} else {


### PR DESCRIPTION
## Proposed changes

This PR sets default FIWARE Service Path to `/` on NGSIv2 in rm command.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
