### PR TITLE
Set default FIWARE Service Path to '/' in cp command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NGSI Go v0.8.4-next
 
+-   Improve: Set default FIWARE Service Path to "/" in cp command (#180)
 -   Improve: Set default FIWARE Service Path to "/" in rm command (#179)
 -   Hardening: Support Kong (#178)
 -   Hardening: Add insecureSkipVerify option (#177)

--- a/internal/ngsicmd/copy.go
+++ b/internal/ngsicmd/copy.go
@@ -86,6 +86,15 @@ func copy(c *cli.Context) error {
 		return &ngsiCmdError{funcName, 7, "source and destination are same", nil}
 	}
 
+	if source.IsNgsiV2() && source.Scope == "" {
+		source.Scope = "/"
+		source.Headers["Fiware-ServicePath"] = "/"
+	}
+	if destination.IsNgsiV2() && destination.Scope == "" {
+		destination.Scope = "/"
+		destination.Headers["Fiware-ServicePath"] = "/"
+	}
+
 	if source.IsNgsiV2() && destination.IsNgsiV2() {
 		if c.Bool("ngsiV1") {
 			f = copyV1V1


### PR DESCRIPTION
## Proposed changes

This PR sets default FIWARE Service Path to '/' for NGSIv2 host in cp command.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [X] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
