### PR TITLE
Add --serial flag to print serial value as NGSI Go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NGSI Go v0.9.0-next
 
+-   Improve: Add --serial flag to print serial value as NGSI Go version (#204)
 -   Improve: Add colon as a valid character for alias name (#203)
 -   Improve: Support version command for Keyrock (#202)
 -   Improve: Large scale refactoring (#200)

--- a/e2e/cases/1000_common/0002_ngsi_version.test
+++ b/e2e/cases/1000_common/0002_ngsi_version.test
@@ -32,3 +32,12 @@ ngsi --version
 ```
 ngsi version REGEX(.*)
 ```
+
+#
+# 0002 ngsi --serial
+#
+ngsi --serial
+
+```
+REGEX([0-9]+)
+```

--- a/internal/ngsicli/help.go
+++ b/internal/ngsicli/help.go
@@ -43,6 +43,12 @@ func printVersion(c *Context, token *token) bool {
 	if arg != nil && (*arg == "--version" || *arg == "-v") {
 		fmt.Fprintf(c.Ngsi.StdWriter, "ngsi version %s\n", c.App.Version)
 		return true
+	} else if arg != nil && *arg == "--serial" {
+		var x, y, z int
+		if _, err := fmt.Sscanf(c.App.Version, "%d.%d.%d", &x, &y, &z); err == nil {
+			fmt.Fprintf(c.Ngsi.StdWriter, "%d%02d%02d", x, y, z)
+		}
+		return true
 	}
 	_ = token.Prev()
 

--- a/internal/ngsicli/help_test.go
+++ b/internal/ngsicli/help_test.go
@@ -63,6 +63,19 @@ func TestPrintVersionV(t *testing.T) {
 	assert.Equal(t, expected, buffer.String())
 }
 
+func TestPrintSerial(t *testing.T) {
+	buffer := &bytes.Buffer{}
+
+	c := &Context{Ngsi: &ngsilib.NGSI{StdWriter: buffer}, App: &App{Version: "0.9.0 (git_hash:bfd1ec240a8a8421929e2923f8fb5d3f6cab18ab"}}
+	token := newToken([]string{"--serial"})
+
+	actual := printVersion(c, token)
+
+	assert.Equal(t, true, actual)
+	expected := "00900"
+	assert.Equal(t, expected, buffer.String())
+}
+
 func TestPrintVersionFalse(t *testing.T) {
 	buffer := &bytes.Buffer{}
 


### PR DESCRIPTION
## Proposed changes

This PR adds --serial flag to print serial value as NGSI Go version.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A