### PR TITLE
Add --raw flag for Subscription command (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NGSI Go v0.9.0-next
 
+-   Hardening: Add --raw flag for Subscription command (#212)
 -   Hardening: Avoid creating duplicate role name in Keyrock (#210)
 -   Hardening: Add --overWrite flag for overwriting broker/server alias (#209)
 -   Hardening: Add --configDir global flag (#208)

--- a/docs/ngsi/create.md
+++ b/docs/ngsi/create.md
@@ -250,6 +250,7 @@ ngsi create [command options] subscription [options]
 | --exceptAttrs VALUE       | exceptAttrs (v2)                                       |
 | --attrsFormat VALUE       | attrsFormat (v2)                                       |
 | --safeString VALUE        | use safe string (VALUE: on/off)                        |
+| --raw                     | handle raw data (default: false)                       |
 | --help                    | show help (default: true)                              |
 
 ### Example for NGSIv2

--- a/docs/ngsi/get.md
+++ b/docs/ngsi/get.md
@@ -355,6 +355,7 @@ ngsi get [common options] subscription [options]
 | --localTime               | localTime (default: false)             |
 | --pretty, -P              | pretty format (default: false)         |
 | --safeString VALUE        | use safe string (VALUE: on/off)        |
+| --raw                     | handle raw data (default: false)       |
 | --help                    | show help (default: true)              |
 
 ### Examples for NGSIv2

--- a/docs/ngsi/update.md
+++ b/docs/ngsi/update.md
@@ -198,6 +198,7 @@ ngsi update [common options] subscription [options]
 | --exceptAttrs VALUE       | exceptAttrs (v2)                                       |
 | --attrsFormat VALUE       | attrsFormat (v2)                                       |
 | --safeString VALUE        | use safe string (VALUE: on/off)                        |
+| --raw                     | handle raw data (default: false)                       |
 | --help                    | show help (default: true)                              |
 
 ### Example

--- a/e2e/cases/1000_common/0003_help.test
+++ b/e2e/cases/1000_common/0003_help.test
@@ -4852,6 +4852,7 @@ OPTIONS:
    --exceptAttrs VALUE        exceptAttrs (v2)
    --attrsFormat VALUE        attrsFormat (v2)
    --safeString VALUE         use safe string (VALUE: on/off)
+   --raw                      handle raw data (default: false)
    --help                     show help (default: true)
 
 GLOBAL OPTIONS:
@@ -5576,6 +5577,7 @@ OPTIONS:
    --localTime                localTime (default: false)
    --pretty, -P               pretty format (default: false)
    --safeString VALUE         use safe string (VALUE: on/off)
+   --raw                      handle raw data (default: false)
    --help                     show help (default: true)
 
 GLOBAL OPTIONS:
@@ -6397,6 +6399,7 @@ OPTIONS:
    --exceptAttrs VALUE        exceptAttrs (v2)
    --attrsFormat VALUE        attrsFormat (v2)
    --safeString VALUE         use safe string (VALUE: on/off)
+   --raw                      handle raw data (default: false)
    --help                     show help (default: true)
 
 GLOBAL OPTIONS:

--- a/e2e/cases/4000_ngsi-v2/9002_issue_201_subs.test
+++ b/e2e/cases/4000_ngsi-v2/9002_issue_201_subs.test
@@ -1,0 +1,239 @@
+# MIT License
+#
+# Copyright (c) 2020-2021 Kazuhito Suda
+#
+# This file is part of NGSI Go
+#
+# https://github.com/lets-fiware/ngsi-go
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# Related issues:
+#  https://github.com/lets-fiware/ngsi-go/issues/201
+
+#
+# 0001 Create entity (400 Bad Request)
+#
+ngsi create --host orion subscription \
+--data '{
+  "description": "Test Notification",
+  "subject": {
+    "entities": [
+      {
+        "idPattern": "Alert.*",
+        "type": "Alert"
+      }
+    ],
+    "condition": {
+      "attrs": []
+    }
+  },
+  "notification": {
+    "httpCustom": {
+      "url": "http://dev/null",
+      "headers": {
+        "fiware-shared-key": "test"
+      }
+    },
+    "attrsFormat": "keyValues"
+  }
+}'
+
+
+```1
+subscriptionsCreateV2005 400 Bad Request {"error":"BadRequest","description":"condition is empty"}
+```
+
+#
+# 0002 Create entity --raw
+#
+ngsi create --host orion subscription --raw \
+--data '{
+  "description": "Test Notification",
+  "subject": {
+    "entities": [
+      {
+        "idPattern": "Alert.*",
+        "type": "Alert"
+      }
+    ],
+    "condition": {
+      "attrs": []
+    }
+  },
+  "notification": {
+    "httpCustom": {
+      "url": "http://dev/null",
+      "headers": {
+        "fiware-shared-key": "test"
+      }
+    },
+    "attrsFormat": "keyValues"
+  }
+}'
+
+```
+REGEX(.*)
+```
+
+#
+# 0003 Save subscription id
+#
+$id=$$
+
+#
+# 0004 Get subscription
+#
+ngsi get subscription --id $id --pretty
+
+```
+{
+  "id": "REGEX(.*)",
+  "description": "Test Notification",
+  "subject": {
+    "entities": [
+      {
+        "idPattern": "Alert.*",
+        "type": "Alert"
+      }
+    ],
+    "condition": {}
+  },
+  "notification": {
+    "onlyChangedAttrs": false,
+    "httpCustom": {
+      "url": "http://dev/null",
+      "headers": {
+        "fiware-shared-key": "test"
+      }
+    },
+    "attrsFormat": "keyValues"
+  },
+  "status": "active"
+}
+```
+
+#
+# 0005 Get subscription --raw
+#
+ngsi get subscription --id $id --pretty --raw
+
+```
+{
+  "id": "REGEX(.*)",
+  "description": "Test Notification",
+  "status": "active",
+  "subject": {
+    "entities": [
+      {
+        "idPattern": "Alert.*",
+        "type": "Alert"
+      }
+    ],
+    "condition": {
+      "attrs": []
+    }
+  },
+  "notification": {
+    "attrs": [],
+    "onlyChangedAttrs": false,
+    "attrsFormat": "keyValues",
+    "httpCustom": {
+      "url": "http://dev/null",
+      "headers": {
+        "fiware-shared-key": "test"
+      }
+    }
+  }
+}
+```
+
+#
+# 0006 Update subscription (400 Bad Request)
+#
+ngsi update --host orion subscription --id $id \
+--data '{
+  "description": "Test Notification",
+  "subject": {
+    "entities": [
+      {
+        "idPattern": "Alert.*",
+        "type": "Alert"
+      }
+    ],
+    "condition": {
+      "attrs": []
+    }
+  },
+  "notification": {
+    "httpCustom": {
+      "url": "http://dev/null",
+      "headers": {
+        "fiware-shared-key": "test"
+      }
+    },
+    "attrsFormat": "keyValues"
+  }
+}'
+
+```1
+subscriptionsUpdateV2005 400 Bad Request {"error":"BadRequest","description":"condition is empty"} REGEX(.*)
+```
+
+#
+# 0007 Update subscription --raw
+#
+ngsi update --host orion subscription --id $id --raw \
+--data '{
+  "description": "Test Notification",
+  "subject": {
+    "entities": [
+      {
+        "idPattern": "Alert.*",
+        "type": "Alert"
+      }
+    ],
+    "condition": {
+      "attrs": []
+    }
+  },
+  "notification": {
+    "httpCustom": {
+      "url": "http://dev/null",
+      "headers": {
+        "fiware-shared-key": "test"
+      }
+    },
+    "attrsFormat": "keyValues"
+  }
+}'
+
+```
+REGEX(.*)
+```
+
+#
+# 9999 Delete subscription
+#
+ngsi delete --host orion subscription --id $id
+
+```
+```

--- a/internal/ngsicmd/command.go
+++ b/internal/ngsicmd/command.go
@@ -301,6 +301,7 @@ var CreateCmd = ngsicli.Command{
 				exceptAttrsFlag,
 				attrsFormatFlag,
 				ngsicli.SafeStringFlag,
+				rawFlag,
 				notifyURLFlag,
 				getFlag,
 			},
@@ -592,6 +593,7 @@ var GetCmd = ngsicli.Command{
 				localTimeFlag,
 				ngsicli.PrettyFlag,
 				ngsicli.SafeStringFlag,
+				rawFlag,
 			},
 			RequiredFlags: []string{"id"},
 			Action: func(c *ngsicli.Context, ngsi *ngsilib.NGSI, client *ngsilib.Client) error {
@@ -969,6 +971,7 @@ var UpdateCmd = ngsicli.Command{
 				exceptAttrsFlag,
 				attrsFormatFlag,
 				ngsicli.SafeStringFlag,
+				rawFlag,
 				notifyURLFlag,
 				getFlag,
 			},

--- a/internal/ngsicmd/flags.go
+++ b/internal/ngsicmd/flags.go
@@ -476,6 +476,10 @@ var (
 		Name:  "skipForwarding",
 		Usage: "skip forwarding to CPrs (v2)",
 	}
+	rawFlag = &ngsicli.BoolFlag{
+		Name:  "raw",
+		Usage: "handle raw data",
+	}
 )
 
 var (

--- a/internal/ngsicmd/subscriptions_test.go
+++ b/internal/ngsicmd/subscriptions_test.go
@@ -129,7 +129,7 @@ func TestSubscriptionsCreateErrorV2(t *testing.T) {
 
 	if assert.Error(t, err) {
 		ngsiErr := err.(*ngsierr.NgsiError)
-		assert.Equal(t, 3, ngsiErr.ErrNo)
+		assert.Equal(t, 4, ngsiErr.ErrNo)
 		assert.Equal(t, "http error", ngsiErr.Message)
 	}
 }
@@ -167,7 +167,7 @@ func TestSubscriptionsUpdateErrorV2(t *testing.T) {
 
 	if assert.Error(t, err) {
 		ngsiErr := err.(*ngsierr.NgsiError)
-		assert.Equal(t, 3, ngsiErr.ErrNo)
+		assert.Equal(t, 4, ngsiErr.ErrNo)
 		assert.Equal(t, "http error", ngsiErr.Message)
 	}
 }


### PR DESCRIPTION
## Proposed changes

This PR adds --raw flag for Subscription command. It fixes the issue #201.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [X] I have added tests that prove my fix is effective or that my feature works
-   [X] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A