### PR TITLE
Allows to create subs even if specifying only uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NGSI Go v0.10.0-next
 
+-   Hardening: Allows to create subs even if specifying only uri (#224)
 -   Update: Update Orion to 3.5.0 (#223)
 -   Update: Update copyright (#222)
 -   Fix: Fix incorrect link in docs/usage.md (#221)

--- a/e2e/cases/4000_ngsi-v2/9003_subs_only_uri.test
+++ b/e2e/cases/4000_ngsi-v2/9003_subs_only_uri.test
@@ -1,0 +1,75 @@
+# MIT License
+#
+# Copyright (c) 2020-2022 Kazuhito Suda
+#
+# This file is part of NGSI Go
+#
+# https://github.com/lets-fiware/ngsi-go
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# 0001 Create subscription --uri
+#
+ngsi create --host orion subscription --uri http://localhost:1026
+
+```
+REGEX(.*)
+```
+
+#
+# 0002 Save subscription id
+#
+$id=$$
+
+#
+# 0003 Get subscription
+#
+ngsi get subscription --id $id --pretty
+
+```
+{
+  "id": "REGEX(.*)",
+  "subject": {
+    "entities": [
+      {
+        "idPattern": ".*"
+      }
+    ],
+    "condition": {}
+  },
+  "notification": {
+    "onlyChangedAttrs": false,
+    "http": {
+      "url": "http://localhost:1026"
+    },
+    "attrsFormat": "normalized"
+  },
+  "status": "active"
+}
+```
+
+#
+# 9999 Delete subscription
+#
+ngsi delete --host orion subscription --id $id
+
+```
+```

--- a/internal/ngsicmd/subscriptionsV2.go
+++ b/internal/ngsicmd/subscriptionsV2.go
@@ -330,6 +330,16 @@ func subscriptionsCreateV2(c *ngsicli.Context, ngsi *ngsilib.NGSI, client *ngsil
 			return ngsierr.New(funcName, 2, err.Error(), err)
 		}
 
+		if !c.IsSet("entityId") && !c.IsSet("idPattern") && !c.IsSet("type") && !c.IsSet("typePattern") {
+			if t.Subject == nil {
+				t.Subject = new(subscriptionSubjectV2)
+			}
+			if len(t.Subject.Entities) == 0 {
+				t.Subject.Entities = append(t.Subject.Entities, *new(subscriptionEntityV2))
+			}
+			t.Subject.Entities[0].IDPattern = ".*"
+		}
+
 		b, err = ngsilib.JSONMarshalEncode(&t, true)
 		if err != nil {
 			return ngsierr.New(funcName, 3, err.Error(), err)

--- a/internal/ngsicmd/subscriptionsV2_test.go
+++ b/internal/ngsicmd/subscriptionsV2_test.go
@@ -616,6 +616,26 @@ func TestSubscriptionsCreateV2(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsCreateV2OnlyURI(t *testing.T) {
+	c := setupTest([]string{"create", "subscription", "--host", "orion", "--uri", "http://ngsiproxy"})
+
+	reqRes := helper.MockHTTPReqRes{}
+	reqRes.Res.StatusCode = http.StatusCreated
+	reqRes.ReqData = []byte(`{"subject":{"entities":[{"idPattern":".*"}]},"notification":{"http":{"url":"http://ngsiproxy"}}}`)
+	reqRes.Path = "/v2/subscriptions"
+	reqRes.ResHeader = http.Header{"Location": []string{"/v2/subscriptions/5f0a44789dd803416ccbf15c"}}
+
+	helper.SetClientHTTP(c, reqRes)
+
+	err := subscriptionsCreateV2(c, c.Ngsi, c.Client)
+
+	if assert.NoError(t, err) {
+		actual := helper.GetStdoutString(c)
+		expected := "5f0a44789dd803416ccbf15c\n"
+		assert.Equal(t, expected, actual)
+	}
+}
+
 func TestSubscriptionsCreateV2DataRaw(t *testing.T) {
 	c := setupTest([]string{"create", "subscription", "--host", "orion", "--raw", "--data", `{"description":"TestNotification","subject":{"entities":[{"idPattern":"Alert.*","type":"Alert"}],"condition":{"attrs":[]}},"notification":{"httpCustom":{"url":"http://dev/null","headers":{"fiware-shared-key":"test"}},"attrsFormat":"keyValues"}}`})
 


### PR DESCRIPTION
## Proposed changes

This PR allows to create a subscription even if specifying only the `--uri` option.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A