### PR TITLE
Fix #228 that no version and revision are printed when error level is higher than info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NGSI Go v0.10.0-next
 
+-   Fix: Fix issue #228 that no version and revision are printed when error level is higher than info (#229)
 -   Update: Update golang to 1.17.6 (#227)
 -   Hardening: Support version command for Orion-LD (#226)
 -   Update: Update Orion-LD to 1.0.1 (#225)

--- a/e2e/cases/1000_common/1001_stderr.test
+++ b/e2e/cases/1000_common/1001_stderr.test
@@ -30,7 +30,7 @@
 ngsi --stderr info version --host unknown
 
 ```1
- (git_hash:)
+REGEX(.*)
 Run001 error host: unknown
 ngsiRun005 error host: unknown
 newClient001 error host: unknown

--- a/internal/ngsimain/ngsi.go
+++ b/internal/ngsimain/ngsi.go
@@ -69,6 +69,9 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	bufStdout := bufio.NewWriter(stdout)
 	ngsi.InitLog(bufStdin, bufStdout, stderr)
 
+	ngsicli.Version = Version
+	ngsicli.Revision = Revision
+
 	Version = fmt.Sprintf("%s (git_hash:%s)", Version, Revision)
 
 	app := NewNgsiApp()


### PR DESCRIPTION
## Proposed changes

This PR fixes issue #228 that no version and revision are printed when error level is higher than info.

```
$ ngsi --stderr info create --host orion subscription --type abc --typePattern abc
0.10.0-next (git_hash:e2e22bf32a7ea80b32d19d83f75c380eff49e981)
subscriptionsCreateV2002 type or typePattern
setSubscriptionValuesV2004 type or typePattern
abnormal termination
```

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A