### PR TITLE
Fix S1001 error in gosimple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NGSI Go v0.12.0-next
+
+-   Fix: Fix gosimple S1001 error (#243)
+
 ## NGSI Go v0.12.0 - March 19, 2022
 
 -   Update: Extend the length limit of alias name (#236)

--- a/e2e/ngsi-test/Dockerfile
+++ b/e2e/ngsi-test/Dockerfile
@@ -46,7 +46,7 @@ RUN \
         bash=5.0.17-r0 \
         bash-completion=2.10-r0 \
         jq=1.6-r1 \
-        curl=7.79.1-r0 && \
+        curl=7.79.1-r1 && \
     echo "source /usr/share/bash-completion/bash_completion" >> /root/.bashrc && \
     echo "source /usr/share/bash-compeletion/completions/ngsi_bash_autocomplete" >> /root/.bashrc
 

--- a/internal/helper/ioutil_lib.go
+++ b/internal/helper/ioutil_lib.go
@@ -57,9 +57,7 @@ func (i *MockIoutilLib) ReadFull(r io.Reader, buf []byte) (n int, err error) {
 		return 0, i.ReadFullErr
 	}
 	if i.ReadFullData != nil {
-		for i, v := range i.ReadFullData {
-			buf[i] = v
-		}
+		copy(buf, i.ReadFullData)
 		return len(buf), nil
 	}
 	return io.ReadFull(r, buf)

--- a/internal/ngsicli/helper_test.go
+++ b/internal/ngsicli/helper_test.go
@@ -561,9 +561,7 @@ func (i *MockIoutilLib) ReadFull(r io.Reader, buf []byte) (n int, err error) {
 		return 0, i.ReadFullErr
 	}
 	if i.ReadFullData != nil {
-		for i, v := range i.ReadFullData {
-			buf[i] = v
-		}
+		copy(buf, i.ReadFullData)
 		return len(buf), nil
 	}
 	return io.ReadFull(r, buf)


### PR DESCRIPTION
## Proposed changes

This PR fixes  S1001 error in gosimple.

```
  Error: S1001: should use copy() instead of a loop (gosimple)
```

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/ngsi-go/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/ngsi-go/blob/main/ngsi-go-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A